### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/tools/sigma/config/collection.py
+++ b/tools/sigma/config/collection.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from collections import Iterable
+from collections.abc import Iterable
 from pathlib import Path
 import sys
 import re


### PR DESCRIPTION
As per the Warning:
```
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```